### PR TITLE
Mask sanitized value length

### DIFF
--- a/lib/treblle/utils/hash_sanitizer.rb
+++ b/lib/treblle/utils/hash_sanitizer.rb
@@ -32,7 +32,7 @@ module Treblle
         end
 
         def sanitize_value(key, value, sensitive_attrs)
-          sensitive_attrs.include?(key.to_s) ? '*' * value.to_s.length : value
+          sensitive_attrs.include?(key.to_s) ? "*****" : value
         end
       end
     end

--- a/spec/lib/utils/hash_sanitizer_spec.rb
+++ b/spec/lib/utils/hash_sanitizer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Treblle::Utils::HashSanitizer do
 
   context 'when given a hash with sensitive attributes' do
     let(:input_hash) { { name: 'John', password: 'secretpassword', credit_card: '1234567890123456' } }
-    let(:expected_subject) { { name: 'John', password: '**************', credit_card: '****************' } }
+    let(:expected_subject) { { name: 'John', password: '*****', credit_card: '*****' } }
 
     it 'replaces sensitive attribute values with asterisks' do
       expect(subject).to eq(expected_subject)
@@ -42,7 +42,7 @@ RSpec.describe Treblle::Utils::HashSanitizer do
 
   context 'when given a hash with nested hashes' do
     let(:input_hash) { { user: { name: 'John', password: 'secretpassword' } } }
-    let(:expected_subject) { { user: { name: 'John', password: '**************' } } }
+    let(:expected_subject) { { user: { name: 'John', password: '*****' } } }
 
     it 'replaces sensitive attribute values with asterisks' do
       expect(subject).to eq(expected_subject)
@@ -54,7 +54,7 @@ RSpec.describe Treblle::Utils::HashSanitizer do
       { users: [{ name: 'John', password: 'secretpassword' }, { name: 'Jane', password: 'anotherpassword' }] }
     end
     let(:expected_subject) do
-      { users: [{ name: 'John', password: '**************' }, { name: 'Jane', password: '***************' }] }
+      { users: [{ name: 'John', password: '*****' }, { name: 'Jane', password: '*****' }] }
     end
 
     it 'replaces sensitive attribute values with asterisks' do


### PR DESCRIPTION
### Detail
This pull request sets the masked value to a fixed placeholder.

### Issue Addressed

There is no point in revealing the length of the masked value. Therefore it is replaced with fixed value `*****`.